### PR TITLE
Fix deprecation warnings

### DIFF
--- a/addon/components/ember-cli-spinner.js
+++ b/addon/components/ember-cli-spinner.js
@@ -28,7 +28,6 @@ export default Component.extend({
   didInsertElement: function () {
     let spinner = this.get("spinner");
     let type = this.get("type");
-    let color = this.get("color");
     this.setAnimation(type); //Set Spinner Type
     spinner.add(this);
   },

--- a/addon/components/ember-cli-spinner.js
+++ b/addon/components/ember-cli-spinner.js
@@ -6,7 +6,7 @@ const {
   inject,
   run
 } = Ember;
-
+const { escapeExpression } = Ember.Handlebars.Utils;
 export default Component.extend({
   layout: layout,
   timeout: undefined,
@@ -17,6 +17,12 @@ export default Component.extend({
   bgColor: "rgba(0, 0, 0, 0.5)",
   height: "40px",
   width: "40px",
+  bgColorStyle: Ember.computed('bgColor', function() {
+    return Ember.String.htmlSafe(escapeExpression('background:' + this.get('bgColor') + ';'));
+  }),
+  sizeStyle: Ember.computed('height','width', function() {
+    return Ember.String.htmlSafe(escapeExpression('height:' + this.get('height')+ ';width:' + this.get('width') + ';'));
+  }),
   spinner: inject.service(),
   color: "white",
   didInsertElement: function () {

--- a/addon/templates/components/ember-cli-spinner.hbs
+++ b/addon/templates/components/ember-cli-spinner.hbs
@@ -1,7 +1,7 @@
 {{#if isShow}}
-  <div class="ember-cli-spinner" style="background:{{bgColor}};">
+  <div class="ember-cli-spinner" style={{bgColorStyle}}>
     <div class="spinner">
-      <div class="{{className}} {{color}}" style="height:{{height}};width:{{width}};">
+      <div class="{{className}} {{color}}" style={{sizeStyle}}>
         {{#each counters as |counter|}}
           <div class="{{className}}{{counter}} sk-child {{color}}"></div>
         {{/each}}


### PR DESCRIPTION
Deprecation warnings are shown, due to not escaping styling attribute.
See : [http://emberjs.com/deprecations/v1.x/#toc_warning-when-binding-style-attributes]

This is a quick fix.
