### PR TITLE
Relax ember-cli-htmlbars version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9"
+    "ember-cli-htmlbars": "^1.0.11"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Hello,
the version of ember-cli-htmlbars has been changed in `devDependencies`, but not in `dependencies` ;-)
This causes ember-cli-htmlbars not to update, and throws deprecation warnings with recent ember-cli...
